### PR TITLE
Handle mapping of covariance type abbreviations to functions within Cpp-level API (Resolves #69)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Type: Package
 Package: mmrm
 Title: Mixed Models for Repeated Measures
-Version: 0.0.0.9011
+Version: 0.0.0.9010
 Authors@R: c(
     person("Daniel", "Sabanes Bove", , "daniel.sabanes_bove@roche.com", role = c("aut", "cre")),
     person("Julia", "Dedic", , "julia.dedic@roche.com", role = "aut"),
     person("Brian Matthew", "Lang", , "brian.lang@msd.com", role = "aut"),
+    person("Doug", "Kelkhoff", , "kelkhoff.douglas@gene.com", role = "aut"),
     person("Craig", "Gower-Page", , "craig.gower-page@roche.com", role = "aut"),
-    person("Alessandro", "Noci", , "alessandro.noci@roche.com", role = "aut"),
-    person("Doug", "Kelkhoff", , "kelkhoff.douglas@gene.com", role = "aut")
+    person("Alessandro", "Noci", , "alessandro.noci@roche.com", role = "aut")
   )
 Description: Mixed models for repeated measures (MMRM) are a popular
     choice for individually randomized trials with longitudinal continuous

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,14 @@
 Type: Package
 Package: mmrm
 Title: Mixed Models for Repeated Measures
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R: c(
     person("Daniel", "Sabanes Bove", , "daniel.sabanes_bove@roche.com", role = c("aut", "cre")),
     person("Julia", "Dedic", , "julia.dedic@roche.com", role = "aut"),
     person("Brian Matthew", "Lang", , "brian.lang@msd.com", role = "aut"),
     person("Craig", "Gower-Page", , "craig.gower-page@roche.com", role = "aut"),
-    person("Alessandro", "Noci", , "alessandro.noci@roche.com", role = "aut")
+    person("Alessandro", "Noci", , "alessandro.noci@roche.com", role = "aut"),
+    person("Doug", "Kelkhoff", , "kelkhoff.douglas@gene.com", role = "aut")
   )
 Description: Mixed models for repeated measures (MMRM) are a popular
     choice for individually randomized trials with longitudinal continuous

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
-# mmrm 0.0.0.9010
+# mmrm 0.0.0.9011
 
 Initialized package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
-# mmrm 0.0.0.9011
+# mmrm 0.0.0.9010
 
 Initialized package.

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -121,7 +121,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
 #'     indices for each subject.
 #' - `subject_n_visits`: length `n_subjects` `integer` containing the number of
 #'     observed visits for each subjects. So the sum of this vector equals `n`.
-#' - `cov_type`: `int` specifying the covariance type.
+#' - `cov_type`: `chr` value specifying the covariance type.
 #' - `reml`: `int` specifying whether REML estimation is used (1), otherwise ML (0).
 #'
 #' @details Note that the `subject_var` must not be factor but can also be character.
@@ -165,7 +165,6 @@ h_mmrm_tmb_data <- function(formula_parts,
   subject_zero_inds <- which(!duplicated(full_frame[[formula_parts$subject_var]])) - 1L
   subject_n_visits <- c(utils::tail(subject_zero_inds, -1L), nrow(full_frame)) - subject_zero_inds
   assert_true(identical(subject_n_visits, as.integer(table(full_frame[[formula_parts$subject_var]]))))
-  cov_type <- formula_parts$cov_type
 
   structure(
     list(
@@ -177,7 +176,7 @@ h_mmrm_tmb_data <- function(formula_parts,
       n_subjects = n_subjects,
       subject_zero_inds = subject_zero_inds,
       subject_n_visits = subject_n_visits,
-      cov_type = cov_type,
+      cov_type = formula_parts$cov_type,
       reml = as.integer(reml)
     ),
     class = "mmrm_tmb_data"

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -121,7 +121,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
 #'     indices for each subject.
 #' - `subject_n_visits`: length `n_subjects` `integer` containing the number of
 #'     observed visits for each subjects. So the sum of this vector equals `n`.
-#' - `cov_type`: `chr` value specifying the covariance type.
+#' - `cov_type`: `string` value specifying the covariance type.
 #' - `reml`: `int` specifying whether REML estimation is used (1), otherwise ML (0).
 #'
 #' @details Note that the `subject_var` must not be factor but can also be character.

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -165,16 +165,7 @@ h_mmrm_tmb_data <- function(formula_parts,
   subject_zero_inds <- which(!duplicated(full_frame[[formula_parts$subject_var]])) - 1L
   subject_n_visits <- c(utils::tail(subject_zero_inds, -1L), nrow(full_frame)) - subject_zero_inds
   assert_true(identical(subject_n_visits, as.integer(table(full_frame[[formula_parts$subject_var]]))))
-
-  cov_type <- as.integer(switch(formula_parts$cov_type,
-    us = 1,
-    toep = 2,
-    ar1 = 3,
-    ar1h = 4,
-    ad = 5,
-    cs = 6,
-    csh = 7
-  ))
+  cov_type <- formula_parts$cov_type
 
   structure(
     list(

--- a/man/h_mmrm_tmb_data.Rd
+++ b/man/h_mmrm_tmb_data.Rd
@@ -28,7 +28,7 @@ covariance matrix.
 indices for each subject.
 \item \code{subject_n_visits}: length \code{n_subjects} \code{integer} containing the number of
 observed visits for each subjects. So the sum of this vector equals \code{n}.
-\item \code{cov_type}: \code{chr} value specifying the covariance type.
+\item \code{cov_type}: \code{string} value specifying the covariance type.
 \item \code{reml}: \code{int} specifying whether REML estimation is used (1), otherwise ML (0).
 }
 }

--- a/man/h_mmrm_tmb_data.Rd
+++ b/man/h_mmrm_tmb_data.Rd
@@ -28,7 +28,7 @@ covariance matrix.
 indices for each subject.
 \item \code{subject_n_visits}: length \code{n_subjects} \code{integer} containing the number of
 observed visits for each subjects. So the sum of this vector equals \code{n}.
-\item \code{cov_type}: \code{int} specifying the covariance type.
+\item \code{cov_type}: \code{chr} value specifying the covariance type.
 \item \code{reml}: \code{int} specifying whether REML estimation is used (1), otherwise ML (0).
 }
 }

--- a/man/mmrm-package.Rd
+++ b/man/mmrm-package.Rd
@@ -23,9 +23,9 @@ Authors:
 \itemize{
   \item Julia Dedic \email{julia.dedic@roche.com}
   \item Brian Matthew Lang \email{brian.lang@msd.com}
+  \item Doug Kelkhoff \email{kelkhoff.douglas@gene.com}
   \item Craig Gower-Page \email{craig.gower-page@roche.com}
   \item Alessandro Noci \email{alessandro.noci@roche.com}
-  \item Doug Kelkhoff \email{kelkhoff.douglas@gene.com}
 }
 
 }

--- a/man/mmrm-package.Rd
+++ b/man/mmrm-package.Rd
@@ -25,6 +25,7 @@ Authors:
   \item Brian Matthew Lang \email{brian.lang@msd.com}
   \item Craig Gower-Page \email{craig.gower-page@roche.com}
   \item Alessandro Noci \email{alessandro.noci@roche.com}
+  \item Doug Kelkhoff \email{kelkhoff.douglas@gene.com}
 }
 
 }

--- a/src/covariance.h
+++ b/src/covariance.h
@@ -113,7 +113,7 @@ matrix<T> get_compound_symmetry_heterogeneous(const vector<T>& theta, int n_visi
 
 // Creates a new correlation object dynamically.
 template <class T>
-matrix<T> get_covariance_lower_chol(const vector<T>& theta, int n_visits, const std::string& cov_type) {
+matrix<T> get_covariance_lower_chol(const vector<T>& theta, int n_visits, std::string cov_type) {
   matrix<T> result;
 
   if (cov_type == "us") {

--- a/src/covariance.h
+++ b/src/covariance.h
@@ -131,7 +131,7 @@ matrix<T> get_covariance_lower_chol(const vector<T>& theta, int n_visits, const 
   } else if (cov_type == "csh") {
     result = get_compound_symmetry_heterogeneous<T>(theta, n_visits);
   } else {
-    Rf_error(("Unknown covariance type '" + cov_type + "'.").c_str());
+    error(("Unknown covariance type '" + cov_type + "'.").c_str());
   }
 
   return result;

--- a/src/covariance.h
+++ b/src/covariance.h
@@ -111,44 +111,29 @@ matrix<T> get_compound_symmetry_heterogeneous(const vector<T>& theta, int n_visi
   return get_heterogeneous_cov(sd_values, fun);
 }
 
-// Coding of cov_type coming from the R side.
-enum cov_type_code {
-  unstructured_cov = 1,
-  toeplitz_cov = 2,
-  auto_regressive_cov = 3,
-  auto_regressive_heterogeneous_cov = 4,
-  ante_dependence_cov = 5,
-  compound_symmetry_cov = 6,
-  compound_symmetry_heterogeneous_cov = 7
-};
-
 // Creates a new correlation object dynamically.
 template <class T>
-matrix<T> get_covariance_lower_chol(const vector<T>& theta, int n_visits, int cov_type) {
+matrix<T> get_covariance_lower_chol(const vector<T>& theta, int n_visits, const std::string& cov_type) {
   matrix<T> result;
-  switch (cov_type) {
-  case unstructured_cov:
+
+  if (cov_type == "us") {
     result = get_unstructured<T>(theta, n_visits);
-    break;
-  case toeplitz_cov:
+  } else if (cov_type == "toep") {
     result = get_toeplitz<T>(theta, n_visits);
-    break;
-  case auto_regressive_cov:
+  } else if (cov_type == "ar1") {
     result = get_auto_regressive<T>(theta, n_visits);
-    break;
-  case auto_regressive_heterogeneous_cov:
+  } else if (cov_type == "ar1h") {
     result = get_auto_regressive_heterogeneous<T>(theta, n_visits);
-    break;
-  case ante_dependence_cov:
+  } else if (cov_type == "ad") {
     result = get_ante_dependence<T>(theta, n_visits);
-    break;
-  case compound_symmetry_cov:
+  } else if (cov_type == "cs") {
     result = get_compound_symmetry<T>(theta, n_visits);
-    break;
-  case compound_symmetry_heterogeneous_cov:
+  } else if (cov_type == "csh") {
     result = get_compound_symmetry_heterogeneous<T>(theta, n_visits);
-    break;
+  } else {
+    Rf_error(("Unknown covariance type '" + cov_type + "'.").c_str());
   }
+
   return result;
 }
 

--- a/src/mmrm.cpp
+++ b/src/mmrm.cpp
@@ -35,7 +35,7 @@ Type objective_function<Type>::operator() ()
   DATA_INTEGER(n_subjects);        // Number of subjects.
   DATA_IVECTOR(subject_zero_inds); // Starting indices for each subject (0-based) (length n_subjects).
   DATA_IVECTOR(subject_n_visits);  // Number of observed visits for each subject (length n_subjects).
-  DATA_INTEGER(cov_type);         // Covariance type.
+  DATA_STRING(cov_type);           // Covariance type name.
   DATA_INTEGER(reml);              // REML (1)? Otherwise ML (0).
 
   // Read parameters from R.

--- a/src/test-covariance.cpp
+++ b/src/test-covariance.cpp
@@ -126,7 +126,7 @@ context("compound symmetry") {
 context("get_covariance_lower_chol") {
   test_that("get_covariance_lower_chol gives expected unstructured result") {
     vector<double> theta {{log(1.0), log(2.0), 3.0}};
-    matrix<double> result = get_covariance_lower_chol(theta, 2, unstructured_cov);
+    matrix<double> result = get_covariance_lower_chol(theta, 2, "us");
     matrix<double> expected = get_unstructured(theta, 2);
     expect_equal_matrix(result, expected);
   }

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -91,7 +91,7 @@ test_that("h_mmrm_tmb_data works as expected", {
   expect_integer(result$visits_zero_inds, len = 537, lower = 0, upper = 3, any.missing = FALSE)
   expect_identical(result$n_visits, 4L) # 4 visits.
   expect_integer(result$subject_zero_inds, len = 197, unique = TRUE, sorted = TRUE, any.missing = FALSE)
-  expect_identical(result$cov_type, 1L) # unstructured.
+  expect_identical(result$cov_type, "us") # unstructured.
   expect_identical(result$reml, 0L) # ML.
 })
 
@@ -333,6 +333,25 @@ test_that("h_mmrm_tmb_fit works as expected", {
   expect_list(result$opt_details)
   expect_list(result$tmb_object)
   expect_class(result$tmb_data, "mmrm_tmb_data")
+})
+
+test_that("h_mmrm_tmb_fit errors when an invalid covariance type is used", {
+  formula <- FEV1 ~ RACE + us(AVISIT | USUBJID)
+  formula_parts <- h_mmrm_tmb_formula_parts(formula)
+
+  tmb_data <- h_mmrm_tmb_data(formula_parts, fev_data, reml = FALSE)
+  tmb_parameters <- h_mmrm_tmb_parameters(formula_parts, tmb_data, start = NULL)
+
+  tmb_data$cov_type <- "gaaah"
+  expect_error(regex = c("Unknown covariance type 'gaaah'"), {
+    tmb_object <- TMB::MakeADFun(
+      data = tmb_data,
+      parameters = tmb_parameters,
+      hessian = TRUE,
+      DLL = "mmrm",
+      silent = TRUE
+    )
+  })
 })
 
 # h_mmrm_tmb ----

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -343,15 +343,16 @@ test_that("h_mmrm_tmb_fit errors when an invalid covariance type is used", {
   tmb_parameters <- h_mmrm_tmb_parameters(formula_parts, tmb_data, start = NULL)
 
   tmb_data$cov_type <- "gaaah"
-  expect_error(regex = c("Unknown covariance type 'gaaah'"), {
-    tmb_object <- TMB::MakeADFun(
+  expect_error(
+    TMB::MakeADFun(
       data = tmb_data,
       parameters = tmb_parameters,
       hessian = TRUE,
       DLL = "mmrm",
       silent = TRUE
-    )
-  })
+    ),
+    "Unknown covariance type 'gaaah'"
+  )
 })
 
 # h_mmrm_tmb ----


### PR DESCRIPTION
Closes #69

# Description

Previously, `h_mmrm_tmb_data` would store a numeric value which corresponds to a covariance function. This is a somewhat superficial change that provides the covariance type to the model function generator as a string, allowing it to be more meaningful without knowledge of the enum mapping. 

I also added an error condition when the string was unmatched. Previously, an unmatched enum would silently return an empty matrix. This was somewhat guarded against by verifying the condition type in `h_mmrm_tmb_formula_parts`, but perhaps this helps to focus that checking in one place and reduce the need to keep parity between the two bits of code? Of course, if a user would ever need to tease apart `formula_parts` without building a model function, then it's nice to keep the guard in both places.

---

As an aside, this PR took me an embarrassingly long time to put together, so thanks for your patience as I re-familiarize myself with Cpp. I had a ton of issues trying to debug some of the templated code, which seems to give rather uninformative error messages. Any tips on how to better debug this? 



