### PR TITLE
Add `rmarkdown` to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     emmeans (>= 1.6),
     estimability,
     knitr,
+    rmarkdown,
     testthat (>= 3.0.0),
     xml2
 LinkingTo:


### PR DESCRIPTION
Not having it results in:

```
Error: processing vignette 'introduction.Rmd' failed with diagnostics:
   The 'rmarkdown' package should be declared as a dependency of the 'mmrm' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
   --- failed re-building ‘introduction.Rmd’
```

