### PR TITLE
95: fix typo and update covariance structure check

### DIFF
--- a/R/tmb.R
+++ b/R/tmb.R
@@ -95,7 +95,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
     stop(
       "Covariance structure must be of the form `",
       cov_term[[1]],
-      "(VISIT|ID)`"
+      "(time|subject)`"
     )
   }
   visit_term <- cov_content[[2L]]

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -68,7 +68,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   if (length(cov_selected) == 0) {
     stop(
       "Covariance structure must be specified in formula. ",
-      "Possible covariance structure include: ",
+      "Possible covariance structures include: ",
       paste0(cov_functions, collapse = ", ")
     )
   }

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -64,11 +64,23 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   cov_functions <- c("us", "toep", "toeph", "ar1", "ar1h", "ad", "adh", "cs", "csh")
   terms_object <- stats::terms(formula, specials = cov_functions)
   found_specials <- attr(terms_object, "specials")
-  cov_selected <- !sapply(found_specials, is.null)
-  assert_true(identical(sum(cov_selected), 1L))
-  cov_index <- found_specials[[which(cov_selected)]] + 1L # Subtract 1 for `list()`.
+  cov_selected <- Filter(Negate(is.null), found_specials)
+  if (length(cov_selected) == 0) {
+    stop(
+      "Covariance matrix must be specified in formula. ",
+      "Possible covariance matrix include: ",
+      paste0(cov_functions, collapse = ", ")
+    )
+  }
+  if (length(cov_selected) > 1) {
+    stop(
+      "Only one covariance matrix can be specified. ",
+      "Currently specified covariance matrix is:",
+      paste0(names(cov_selected), collapse = ", ")
+    )
+  }
   terms_list <- attr(terms_object, "variables")
-  cov_term <- terms_list[[cov_index]]
+  cov_term <- terms_list[[unlist(cov_selected) + 1L]]
 
   # Remove the covariance term to obtain the model formula.
   model_formula <- stats::update(

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -69,14 +69,14 @@ h_mmrm_tmb_formula_parts <- function(formula) {
     stop(
       "Covariance structure must be specified in formula. ",
       "Possible covariance structures include: ",
-      paste0(cov_functions, collapse = ", ")
+      toString(cov_functions)
     )
   }
   if (length(cov_selected) > 1) {
     stop(
       "Only one covariance structure can be specified. ",
       "Currently specified covariance structures are: ",
-      paste0(names(cov_selected), collapse = ", ")
+      toString(names(cov_selected))
     )
   }
   terms_list <- attr(terms_object, "variables")

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -75,7 +75,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   if (length(cov_selected) > 1) {
     stop(
       "Only one covariance structure can be specified. ",
-      "Currently specified covariance structure is: ",
+      "Currently specified covariance structures are: ",
       paste0(names(cov_selected), collapse = ", ")
     )
   }

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -71,8 +71,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
       "Possible covariance structures include: ",
       toString(cov_functions)
     )
-  }
-  if (length(cov_selected) > 1) {
+  } else if (length(cov_selected) > 1) {
     stop(
       "Only one covariance structure can be specified. ",
       "Currently specified covariance structures are: ",

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -67,15 +67,15 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   cov_selected <- Filter(Negate(is.null), found_specials)
   if (length(cov_selected) == 0) {
     stop(
-      "Covariance matrix must be specified in formula. ",
-      "Possible covariance matrix include: ",
+      "Covariance structure must be specified in formula. ",
+      "Possible covariance structure include: ",
       paste0(cov_functions, collapse = ", ")
     )
   }
   if (length(cov_selected) > 1) {
     stop(
-      "Only one covariance matrix can be specified. ",
-      "Currently specified covariance matrix is:",
+      "Only one covariance structure can be specified. ",
+      "Currently specified covariance structure is:",
       paste0(names(cov_selected), collapse = ", ")
     )
   }
@@ -91,8 +91,13 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   # Parse the covariance term to get covariance type, visit and subject variables.
   assert_true(identical(length(cov_term), 2L)) # 2 because `fun (...)`.
   cov_content <- cov_term[[2L]]
-  assert_true(identical(length(cov_content), 3L)) # 3 because `y | x`.
-  assert_true(identical(as.character(cov_content[[1L]]), "|"))
+  if (!identical(length(cov_content), 3L) || !identical(as.character(cov_content[[1L]]), "|")) {
+    stop(
+      "Covariance structure must be of the form `",
+      cov_term[[1]],
+      "(VISIT|ID)`"
+    )
+  }
   visit_term <- cov_content[[2L]]
   subject_term <- cov_content[[3L]]
   assert_true(identical(length(visit_term), 1L))

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -75,7 +75,7 @@ h_mmrm_tmb_formula_parts <- function(formula) {
   if (length(cov_selected) > 1) {
     stop(
       "Only one covariance structure can be specified. ",
-      "Currently specified covariance structure is:",
+      "Currently specified covariance structure is: ",
       paste0(names(cov_selected), collapse = ", ")
     )
   }

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -64,12 +64,12 @@ test_that("fit_single_optimizer gives error messages", {
   formula <- FEV1 ~ bla
   expect_error(
     h_mmrm_tmb(formula, fev_data),
-    "Assertion on 'identical(sum(cov_selected), 1L)' failed",
+    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
     fixed = TRUE
   )
   expect_error(
     fit_single_optimizer(formula, fev_data),
-    "Assertion on 'identical(sum(cov_selected), 1L)' failed",
+    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -64,12 +64,12 @@ test_that("fit_single_optimizer gives error messages", {
   formula <- FEV1 ~ bla
   expect_error(
     h_mmrm_tmb(formula, fev_data),
-    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
+    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
     fixed = TRUE
   )
   expect_error(
     fit_single_optimizer(formula, fev_data),
-    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
+    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -64,12 +64,18 @@ test_that("fit_single_optimizer gives error messages", {
   formula <- FEV1 ~ bla
   expect_error(
     h_mmrm_tmb(formula, fev_data),
-    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
+    paste(
+      "Covariance structure must be specified in formula.",
+      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    ),
     fixed = TRUE
   )
   expect_error(
     fit_single_optimizer(formula, fev_data),
-    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh",
+    paste(
+      "Covariance structure must be specified in formula.",
+      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    ),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -66,7 +66,7 @@ test_that("fit_single_optimizer gives error messages", {
     h_mmrm_tmb(formula, fev_data),
     paste(
       "Covariance structure must be specified in formula.",
-      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+      "Possible covariance structures include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
     ),
     fixed = TRUE
   )
@@ -74,7 +74,7 @@ test_that("fit_single_optimizer gives error messages", {
     fit_single_optimizer(formula, fev_data),
     paste(
       "Covariance structure must be specified in formula.",
-      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+      "Possible covariance structures include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
     ),
     fixed = TRUE
   )

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -38,15 +38,21 @@ test_that("h_mmrm_tmb_formula_parts works as expected", {
   expect_identical(result, expected)
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + AVISIT + USUBJID),
-    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    paste(
+      "Covariance structure must be specified in formula.",
+      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    )
   )
   expect_error(
-    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + arh1(AVISIT|USUBJID)),
-    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + arh1(AVISIT | USUBJID)),
+    paste(
+      "Covariance structure must be specified in formula.",
+      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    )
   )
   expect_error(
-    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + ar1h(AVISIT|USUBJID) + cs(AVISIT|USUBJID)),
-    "Only one covariance structure can be specified. Currently specified covariance structure is:ar1h, cs"
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + ar1h(AVISIT | USUBJID) + cs(AVISIT | USUBJID)),
+    "Only one covariance structure can be specified. Currently specified covariance structure is: ar1h, cs"
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + cs(AVISIT)),

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -40,23 +40,23 @@ test_that("h_mmrm_tmb_formula_parts works as expected", {
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + AVISIT + USUBJID),
     paste(
       "Covariance structure must be specified in formula.",
-      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+      "Possible covariance structures include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
     )
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + arh1(AVISIT | USUBJID)),
     paste(
       "Covariance structure must be specified in formula.",
-      "Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+      "Possible covariance structures include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
     )
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + ar1h(AVISIT | USUBJID) + cs(AVISIT | USUBJID)),
-    "Only one covariance structure can be specified. Currently specified covariance structure is: ar1h, cs"
+    "Only one covariance structure can be specified. Currently specified covariance structures are: ar1h, cs"
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + cs(AVISIT)),
-    "Covariance structure must be of the form `cs\\(VISIT\\|ID\\)`"
+    "Covariance structure must be of the form `cs\\(time\\|subject\\)`"
   )
 })
 

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -36,6 +36,18 @@ test_that("h_mmrm_tmb_formula_parts works as expected", {
     class = "mmrm_tmb_formula_parts"
   )
   expect_identical(result, expected)
+  expect_error(
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + AVISIT + USUBJID),
+    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+  )
+  expect_error(
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + arh1(AVISIT|USUBJID)),
+    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+  )
+  expect_error(
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + ar1h(AVISIT|USUBJID) + cs(AVISIT|USUBJID)),
+    "Only one covariance matrix can be specified. Currently specified covariance matrix is:ar1h, cs"
+  )
 })
 
 test_that("h_mmrm_tmb_formula_parts works without covariates", {

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -38,15 +38,19 @@ test_that("h_mmrm_tmb_formula_parts works as expected", {
   expect_identical(result, expected)
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + AVISIT + USUBJID),
-    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + arh1(AVISIT|USUBJID)),
-    "Covariance matrix must be specified in formula. Possible covariance matrix include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
+    "Covariance structure must be specified in formula. Possible covariance structure include: us, toep, toeph, ar1, ar1h, ad, adh, cs, csh"
   )
   expect_error(
     h_mmrm_tmb_formula_parts(FEV1 ~ RACE + ar1h(AVISIT|USUBJID) + cs(AVISIT|USUBJID)),
-    "Only one covariance matrix can be specified. Currently specified covariance matrix is:ar1h, cs"
+    "Only one covariance structure can be specified. Currently specified covariance structure is:ar1h, cs"
+  )
+  expect_error(
+    h_mmrm_tmb_formula_parts(FEV1 ~ RACE + cs(AVISIT)),
+    "Covariance structure must be of the form `cs\\(VISIT\\|ID\\)`"
   )
 })
 

--- a/vignettes/covariance.Rmd
+++ b/vignettes/covariance.Rmd
@@ -164,7 +164,7 @@ parameters are used differently in the construction of $P$. Assuming a
 constant variance yields a homogeneous Toeplitz covariance structure
 with total $m$ variance parameters.
 
-## Homogeneous (`ar1`) and Heterogeneous (`arh1`) Autoregressive
+## Homogeneous (`ar1`) and Heterogeneous (`ar1h`) Autoregressive
 
 The autoregressive covariance structure can be motivated by the
 corresponding state-space equation


### PR DESCRIPTION
close #95 

the typo in [vignettes/covariance.Rmd](https://github.com/openpharma/mmrm/compare/95_typo?expand=1#diff-1a86968857585f8d0d042c84415044f4dd62dd4757fdd8175abc4c6a8e7e5ba0) file is updated

now there is a covariance structure checking include

1. no covariance matrix specified
2. covariance matrix specified multiple times
3. covariance matrix does not take the form  `cs(VISIT|ID)`
