### PR TITLE
124: reduce the size using strip

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,4 @@
 PKG_CXXFLAGS = -D TMBAD_FRAMEWORK -D EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS
+strippedLib: $(SHLIB)
+	if test -e "/usr/bin/strip"; then /usr/bin/strip --strip-debug $(SHLIB); fi
+.phony: strippedLib


### PR DESCRIPTION
following 

http://dirk.eddelbuettel.com/blog/2017/08/14/#009_compact_shared_libraries

it seems that the build package can be smaller if strip is enabled

the package is much smaller and the `mmrm.so` object is only 16 mb
