### PR TITLE
fix parallel problem

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -244,7 +244,7 @@ mmrm_control <- function(optimizer = stats::nlminb,
 #' When setting `optimizer = "automatic"`, first the default optimizer
 #' (`L-BFGS-B`) is used to fit the model. If that converges, this is returned.
 #' If not, the other available optimizers from [refit_multiple_optimizers()] are
-#' tried (in parallel if `n_cores` is set and not on Windows).
+#' tried (in parallel if `n_cores` is set and not on Windows, use e.g. [free_cores()]).
 #' If none of the optimizers converge, then the function fails. Otherwise
 #' the best fit is returned.
 #'
@@ -267,7 +267,7 @@ mmrm <- function(formula,
                  weights = NULL,
                  reml = TRUE,
                  optimizer = "automatic",
-                 n_cores = free_cores(),
+                 n_cores = 1L,
                  accept_singular = TRUE) {
   assert_string(optimizer)
   use_automatic <- identical(optimizer, "automatic")

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,10 +68,6 @@ h_record_all_output <- function(expr, remove = list()) {
 #'
 #' @export
 free_cores <- function() {
-  on_cran <- !identical(Sys.getenv("NOT_CRAN"), "true")
-  if (on_cran) {
-    return(1L)
-  }
   all_cores <- parallel::detectCores(all.tests = TRUE)
   busy_cores <-
     if (.Platform$OS.type == "windows") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,11 +68,9 @@ h_record_all_output <- function(expr, remove = list()) {
 #'
 #' @export
 free_cores <- function() {
-  if (requireNamespace("testthat", quietly = TRUE)) {
-    on_cran <- !identical(Sys.getenv("NOT_CRAN"), "true")
-    if (testthat::is_testing() && on_cran) {
-      return(1L)
-    }
+  on_cran <- !identical(Sys.getenv("NOT_CRAN"), "true")
+  if (on_cran) {
+    return(1L)
   }
   all_cores <- parallel::detectCores(all.tests = TRUE)
   busy_cores <-
@@ -81,8 +79,11 @@ free_cores <- function() {
       # This gives e.g.: c("LoadPercentage", "10", "")
       # So we just take the number here.
       load_percent <- as.integer(min(load_percent_string[2L], 100))
-      assert_int(load_percent, lower = 0, upper = 100)
-      ceiling(all_cores * load_percent / 100)
+      if (test_int(load_percent, lower = 0, upper = 100)) {
+        ceiling(all_cores * load_percent / 100)
+      } else {
+        all_cores
+      }
     } else if (.Platform$OS.type == "unix") {
       uptime_string <- system("uptime", intern = TRUE)
       # This gives e.g.:

--- a/man/mmrm.Rd
+++ b/man/mmrm.Rd
@@ -10,7 +10,7 @@ mmrm(
   weights = NULL,
   reml = TRUE,
   optimizer = "automatic",
-  n_cores = free_cores(),
+  n_cores = 1L,
   accept_singular = TRUE
 )
 }
@@ -53,7 +53,7 @@ The covariance structures in the formula can be found in \code{\link{covariance_
 When setting \code{optimizer = "automatic"}, first the default optimizer
 (\code{L-BFGS-B}) is used to fit the model. If that converges, this is returned.
 If not, the other available optimizers from \code{\link[=refit_multiple_optimizers]{refit_multiple_optimizers()}} are
-tried (in parallel if \code{n_cores} is set and not on Windows).
+tried (in parallel if \code{n_cores} is set and not on Windows, use e.g. \code{\link[=free_cores]{free_cores()}}).
 If none of the optimizers converge, then the function fails. Otherwise
 the best fit is returned.
 }

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,3 +1,5 @@
 test_that("free_cores works as expected", {
+  skip_on_cran()
+
   expect_silent(free_cores())
 })


### PR DESCRIPTION
this sets the default to just 1 core. downstream packages or users can still use free_cores() to manually ask for as many cores as are free

[skip vbump]