### PR TITLE
correct run_testthat_tests definition in init.h

### DIFF
--- a/src/init.h
+++ b/src/init.h
@@ -8,10 +8,10 @@
 extern "C" {
 
 /* .Call calls */
-extern SEXP run_testthat_tests();
+extern SEXP run_testthat_tests(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-  {"run_testthat_tests", (DL_FUNC) &run_testthat_tests,  0},
+  {"run_testthat_tests", (DL_FUNC) &run_testthat_tests,  1},
   TMB_CALLDEFS,
   {NULL, NULL, 0}
 };


### PR DESCRIPTION
Problem is that `run_testthat_tests` has one argument which was not present before when the templates were created that we used here. This problem showed only up with specific LTO tests.
- See https://github.com/r-lib/testthat/blob/05b07d4353ff0c2ec81e90a7110476b613a1cd2d/inst/include/testthat/testthat.h#L172 for the definition in testthat.
- See https://github.com/r-lib/testthat/issues/1230 for more info.