### PR TITLE
Allow tests to run without `parallelly` installed

### DIFF
--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -208,6 +208,10 @@ test_that("refit_multiple_optimizers works as expected with default arguments", 
 
 test_that("refit_multiple_optimizers works with parallel computations and selected optimizers", {
   skip_on_cran()
+  skip_if(!isTRUE(parallel::detectCores() > 1), "unable to detect more than one core")
+
+  has_parallelly <- length(find.package("parallelly", quiet = TRUE)) > 0
+  n_cores <- if (has_parallelly) parallelly::availableCores(omit = 1) else 2
 
   fit <- fit_single_optimizer(
     formula = FEV1 ~ RACE + SEX + ARMCD * AVISIT + us(AVISIT | USUBJID),
@@ -222,7 +226,7 @@ test_that("refit_multiple_optimizers works with parallel computations and select
 
   result <- expect_silent(refit_multiple_optimizers(
     fit = fit,
-    n_cores = parallelly::availableCores(omit = 1),
+    n_cores = n_cores,
     optimizers = c("BFGS", "CG")
   ))
   expect_class(result, "mmrm_fit")


### PR DESCRIPTION
Closes #177 

The issue suggested skipping tests that required `parallelly`, but I felt like this was a useful test even if not installed and could otherwise be performed just fine.

Instead, I check whether multiple cores are available. If `parallelly` is available it is used to detect a maximum number of cores, but otherwise the tests are run on a minimum 2 cores.

It sounds like the edge cases that `parallelly` addresses are unlikely to be hit during unit testing and a more conservative fallback would be a suitable substitute. 

Tested against an install without `parallelly` installed. As far as I can tell it's just used for `availableCores` and this is the only thing that would be affected.

