### PR TITLE
adding version constraint for LinkingTo TMB

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
 LinkingTo:
     RcppEigen,
     testthat,
-    TMB
+    TMB (>= 1.9.1)
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
Closes #167

Knocking out another easy fix. This is an important one because the version constraints for LinkingTo are applied at install, while the version constraints for Depends/Imports are applied on-load.

Previously, someone could build a version of the package with an older version of TMB, then update TMB to satisfy the on-load version constraint and find that the package breaks due to version used at install.