### PR TITLE
allow NA in data for prediction; order preserved

### DIFF
--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -62,6 +62,7 @@ predict.mmrm_tmb <- function(
     newdata <- object$tmb_data$data
   }
   assert_data_frame(newdata)
+  orig_names <- row.names(newdata)
   assert_flag(se.fit)
   assert_number(level, lower = 0, upper = 1)
   assert_integer(n_sim, lower = 1)
@@ -91,23 +92,32 @@ predict.mmrm_tmb <- function(
   colnames <- names(Filter(isFALSE, object$tmb_data$x_cols_aliased))
   tmb_data$x_matrix <- tmb_data$x_matrix[, colnames, drop = FALSE]
   predictions <- h_get_prediction(tmb_data, object$theta_est, object$beta_est, object$beta_vcov)
-  res <- data.frame(fit = predictions[, 1])
+  res <- cbind(fit = rep(NA, nrow(newdata)))
+  new_order <- match(row.names(tmb_data$full_frame), orig_names)
+  res[new_order, "fit"] <- predictions[, 1]
   se <- switch(interval,
     "confidence" = sqrt(predictions[, 2]),
     "prediction" = sqrt(h_get_prediction_variance(object, n_sim, tmb_data)),
     "none" = NULL
   )
   if (se.fit && interval != "none") {
-    res <- cbind(res, se = se)
+    res <- cbind(
+      res,
+      se = NA_real_
+    )
+    res[new_order, "se"] <- se
   }
   if (interval != "none") {
     alpha <- 1 - level
-    z <- stats::qnorm(1 - alpha / 2) * se
-    res <- cbind(res,
+    z <- stats::qnorm(1 - alpha / 2) * res[, "se"]
+    res <- cbind(
+      res,
       lwr = res[, "fit"] - z,
       upr = res[, "fit"] + z
     )
   }
+  # use original names
+  row.names(res) <- orig_names
   if (ncol(res) == 1) {
     res <- res[, "fit"]
   }

--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -93,7 +93,7 @@ predict.mmrm_tmb <- function(
   tmb_data$x_matrix <- tmb_data$x_matrix[, colnames, drop = FALSE]
   predictions <- h_get_prediction(tmb_data, object$theta_est, object$beta_est, object$beta_vcov)
   res <- cbind(fit = rep(NA_real_, nrow(newdata)))
-  new_order <- match(row.names(tmb_data$full_frame), orig_names)
+  new_order <- match(row.names(tmb_data$full_frame), orig_row_names)
   res[new_order, "fit"] <- predictions[, 1]
   se <- switch(interval,
     "confidence" = sqrt(predictions[, 2]),
@@ -117,7 +117,7 @@ predict.mmrm_tmb <- function(
     )
   }
   # Use original names.
-  row.names(res) <- orig_names
+  row.names(res) <- orig_row_names
   if (ncol(res) == 1) {
     res <- res[, "fit"]
   }

--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -62,7 +62,7 @@ predict.mmrm_tmb <- function(
     newdata <- object$tmb_data$data
   }
   assert_data_frame(newdata)
-  orig_names <- row.names(newdata)
+  orig_row_names <- row.names(newdata)
   assert_flag(se.fit)
   assert_number(level, lower = 0, upper = 1)
   assert_integer(n_sim, lower = 1)

--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -116,7 +116,7 @@ predict.mmrm_tmb <- function(
       upr = res[, "fit"] + z
     )
   }
-  # use original names
+  # Use original names.
   row.names(res) <- orig_names
   if (ncol(res) == 1) {
     res <- res[, "fit"]

--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -92,7 +92,7 @@ predict.mmrm_tmb <- function(
   colnames <- names(Filter(isFALSE, object$tmb_data$x_cols_aliased))
   tmb_data$x_matrix <- tmb_data$x_matrix[, colnames, drop = FALSE]
   predictions <- h_get_prediction(tmb_data, object$theta_est, object$beta_est, object$beta_vcov)
-  res <- cbind(fit = rep(NA, nrow(newdata)))
+  res <- cbind(fit = rep(NA_real_, nrow(newdata)))
   new_order <- match(row.names(tmb_data$full_frame), orig_names)
   res[new_order, "fit"] <- predictions[, 1]
   se <- switch(interval,

--- a/R/utils.R
+++ b/R/utils.R
@@ -358,7 +358,9 @@ h_default_value <- function(x, y) {
 h_factor_ref <- function(x, ref, var_name = vname(x)) {
   assert_multi_class(ref, c("character", "factor"))
   assert_multi_class(x, c("character", "factor"))
-  uni_values <- as.character(unique(x))
+  # NA can be possible values
+  uni_values <- as.character(na.omit(unique(x)))
+  # no NA in reference
   uni_ref <- as.character(unique(ref))
   assert_character(uni_values, .var.name = var_name)
   assert_subset(uni_values, uni_ref, .var.name = var_name)

--- a/tests/testthat/test-tmb-methods.R
+++ b/tests/testthat/test-tmb-methods.R
@@ -53,13 +53,13 @@ test_that("predict works for only fit values without response", {
   fev_data_no_y$FEV1 <- NA_real_
   y_pred <- expect_silent(predict(object, fev_data_no_y))
   y_hat <- as.vector(m %*% object$beta_est)
-  expect_equal(y_pred, y_hat)
+  expect_equal(y_pred, y_hat, ignore_attr = TRUE)
 })
 
 test_that("predict works for only fit values with response", {
   object <- get_mmrm()
   y_pred <- expect_silent(predict(object, fev_data))
-  expect_equal(y_pred[!is.na(fev_data$FEV1)], object$tmb_data$y_vector)
+  expect_equal(y_pred[!is.na(fev_data$FEV1)], object$tmb_data$y_vector, ignore_attr = TRUE)
   expect_numeric(y_pred[is.na(fev_data$FEV1)])
 })
 

--- a/tests/testthat/test-tmb-methods.R
+++ b/tests/testthat/test-tmb-methods.R
@@ -77,6 +77,50 @@ test_that("predict warns on aliased variables", {
   expect_warning(predict(fit), "In fitted object there are co-linear variables and therefore dropped terms")
 })
 
+test_that("predict will return on correct order", {
+  new_order <- sample(seq_len(nrow(fev_data)))
+  fit <- get_mmrm()
+  fev_data2 <- fev_data
+  fev_data2$FEV1 <- NA_real_
+  predicted <- predict(fit, newdata = fev_data2[new_order, ])
+
+  m <- stats::model.matrix(
+    fit$formula_parts$model_formula,
+    model.frame(fit, data = fev_data2[new_order, ], include = "response_var", na.action = "na.pass")
+  )
+
+  expect_identical(
+    predicted,
+    (m %*% fit$beta_est)[, 1],
+    tolerance = 1e-8
+  )
+})
+
+test_that("predict will return NA if data contains NA in covariates", {
+  new_order <- sample(seq_len(nrow(fev_data)))
+  fit <- get_mmrm()
+  fev_data2 <- fev_data
+  fev_data2$FEV1 <- NA_real_
+  fev_data2$SEX[1:20] <- NA
+  predicted <- predict(fit, newdata = fev_data2[new_order, ], se.fit = TRUE, interval = "confidence")
+
+  m <- stats::model.matrix(
+    fit$formula_parts$model_formula,
+    model.frame(fit, data = fev_data2[new_order, ], include = "response_var", na.action = "na.pass")
+  )
+
+  expect_identical(
+    predicted[, "fit"],
+    (m %*% fit$beta_est)[, 1],
+    tolerance = 1e-8
+  )
+  na_index <- which(new_order <= 20)
+  expect_identical(
+    predicted[na_index, ],
+    matrix(NA_real_, nrow = 20, ncol = 4, dimnames = list(row.names(m)[na_index], c("fit", "se", "lwr", "upr")))
+  )
+})
+
 # model.frame ----
 
 test_that("model.frame works as expected with defaults", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -194,3 +194,10 @@ test_that("h_factor_ref works with character", {
   f <- expect_silent(h_factor_ref(x, ref))
   expect_identical(levels(f), ref)
 })
+
+test_that("h_factor ref allows NA in x", {
+  ref <- c("a", "b", "c")
+  x <- c("a", "b", NA)
+  f <- expect_silent(h_factor_ref(x, ref))
+  expect_identical(levels(f), ref)
+})


### PR DESCRIPTION
close #287 

changes:

1. NA is allowed in new predict data (gives NA in prediction)
2. order follows the original data