### PR TITLE
DOC: Add missing spatial exponential function name

### DIFF
--- a/vignettes/covariance.Rmd
+++ b/vignettes/covariance.Rmd
@@ -222,7 +222,7 @@ The distance matrix is
     \end{pmatrix}
 \]
 
-## Spatial exponential
+## Spatial exponential (`sp_exp`)
 
 For spatial exponential, the covariance structure is defined as follows:
 


### PR DESCRIPTION
This change makes the spatial exponential title consistent with the titles for other covariance structures.


