### PR TITLE
fix make_unique

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -74,24 +74,24 @@ register_on_load <- function(pkg,
 check_package_version <- function(pkg, ver = c(NA_character_, NA_character_)) {
   assert_character(ver, len = 2L)
   pkg_ver <- utils::packageVersion(pkg)
-  ver <- lapply(ver, numeric_version, strict = FALSE)
+  ver <- numeric_version(ver, strict = FALSE)
 
   warn_version <- function(pkg, pkg_ver, ver) {
-    ver_na <- is.na(vapply(ver, is.na, logical(1L)))
+    ver_na <- is.na(ver)
     warning(sprintf(
       "Cannot register mmrm for use with %s (v%s). Version %s required.",
       pkg, pkg_ver,
       if (!any(ver_na)) {
-        sprintf("%s to %s", ver[[1]], ver[[2]])
-      } else if (!is.na(ver[[1]])) {
-        paste0(">= ", ver[[1]])
-      } else if (!is.na(ver[[2]])) {
-        paste0("<= ", ver[[1]])
+        sprintf("%s to %s", ver[1], ver[2])
+      } else if (!is.na(ver[1])) {
+        paste0(">= ", ver[1])
+      } else if (!is.na(ver[2])) {
+        paste0("<= ", ver[2])
       }
     ))
   }
 
-  if (identical(pkg_ver < ver[[1]], TRUE) || identical(pkg_ver > ver[[2]], TRUE)) {
+  if (identical(pkg_ver < ver[1], TRUE) || identical(pkg_ver > ver[2], TRUE)) {
     warn_version(pkg, pkg_ver, ver)
     return(invisible(FALSE))
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -83,9 +83,9 @@ check_package_version <- function(pkg, ver = c(NA_character_, NA_character_)) {
       pkg, pkg_ver,
       if (!any(ver_na)) {
         sprintf("%s to %s", ver[1], ver[2])
-      } else if (!is.na(ver[1])) {
+      } else if (ver_na[2]) {
         paste0(">= ", ver[1])
-      } else if (!is.na(ver[2])) {
+      } else if (ver_na[1]) {
         paste0("<= ", ver[2])
       }
     ))

--- a/src/chol_cache.h
+++ b/src/chol_cache.h
@@ -4,17 +4,6 @@
 #include "covariance.h"
 #include "utils.h"
 
-#include <memory> // header where this is defined
-#if defined(__cpp_lib_make_unique) && (__cpp_lib_make_unique >= 201304)
-using std::make_unique;
-#else
-template<class T, class... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
-{
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-#endif
-
 // Base class of spatial and non-spatial Cholesky.
 template <class Type>
 struct lower_chol_base {
@@ -110,7 +99,7 @@ struct lower_chol_spatial: virtual lower_chol_base<Type> {
 
 template <class T, class Base, class D1, class D2>
 struct cache_obj {
-  std::map<int, std::unique_ptr<Base>> cache;
+  std::map<int, std::shared_ptr<Base>> cache;
   int n_groups;
   bool is_spatial;
   int n_visits;
@@ -120,9 +109,9 @@ struct cache_obj {
     for (int r = 0; r < n_groups; r++) {
       // Use unique pointers here to better manage resource.
       if (is_spatial) {
-        this->cache[r] = make_unique<D1>(theta.segment(r * theta_one_group_size, theta_one_group_size), cov_type);
+        this->cache[r] = std::make_shared<D1>(theta.segment(r * theta_one_group_size, theta_one_group_size), cov_type);
       } else {
-        this->cache[r] = make_unique<D2>(theta.segment(r * theta_one_group_size, theta_one_group_size), n_visits, cov_type);
+        this->cache[r] = std::make_shared<D2>(theta.segment(r * theta_one_group_size, theta_one_group_size), n_visits, cov_type);
       }
     }
   }


### PR DESCRIPTION
use make_shared instead of make_unique

also update the `check_package_version` function to avoid errors like

```
Cannot register mmrm for use with parsnip (v1.0.3). Version 1.0.4 to NA required
```



