### PR TITLE
Don't rerun the check workflow after the Docs workflow finishes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,13 +14,6 @@ on:
       - main
   workflow_dispatch:
 
-  # Rerun workflows once pkgdown has finished running, to add coverage
-  # and unit test report to gh-pages branch.
-  workflow_run:
-    workflows: ["Docs 📚"]
-    types:
-      - completed
-
 jobs:
   audit:
     name: Audit Dependencies 🕵️‍♂️
@@ -36,7 +29,7 @@ jobs:
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/mmrm.png
   coverage:
     name: Coverage 📔
-    uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
+    uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@fix-coverage-reports
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linter:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - fix-coverage-reports
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - fix-coverage-reports
   workflow_dispatch:
 
 jobs:
@@ -30,7 +29,7 @@ jobs:
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/mmrm.png
   coverage:
     name: Coverage 📔
-    uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@fix-coverage-reports
+    uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linter:


### PR DESCRIPTION
This is no longer necessary after we updated the way pkgdown documentation is uploaded to `gh-pages` branch. This change has also previously been propagated to other repositories that use the `r.pkg.template` workflows.