### PR TITLE
unify coordinates and visits_zero_index

### DIFF
--- a/R/tmb.R
+++ b/R/tmb.R
@@ -66,7 +66,6 @@ h_mmrm_tmb_formula_parts <- function(
 #'      `x_matrix`.
 #' - `y_vector`: length `n` `numeric` specifying the overall response vector.
 #' - `weights_vector`: length `n` `numeric` specifying the weights vector.
-#' - `visits_zero_inds`: length `n` `integer` containing zero-based visits indices.
 #' - `n_visits`: `int` with the number of visits, which is the dimension of the
 #'      covariance matrix.
 #' - `n_subjects`: `int` with the number of subjects.
@@ -208,13 +207,11 @@ h_mmrm_tmb_data <- function(formula_parts,
   if (formula_parts$is_spatial) {
     lapply(coordinates, assert_numeric)
     coordinates_matrix <- as.matrix(coordinates)
-    visits_zero_inds <- 0L
     n_visits <- max(subject_n_visits)
   } else {
     assert(identical(ncol(coordinates), 1L))
     assert_factor(coordinates[[1L]])
-    visits_zero_inds <- as.integer(coordinates[[1L]]) - 1L
-    coordinates_matrix <- as.matrix(visits_zero_inds, ncol = 1)
+    coordinates_matrix <- as.matrix(as.integer(coordinates[[1L]]) - 1, ncol = 1)
     n_visits <- nlevels(coordinates[[1L]])
     assert_true(all(subject_n_visits <= n_visits))
   }
@@ -227,7 +224,6 @@ h_mmrm_tmb_data <- function(formula_parts,
       coordinates = coordinates_matrix,
       y_vector = y_vector,
       weights_vector = weights_vector,
-      visits_zero_inds = visits_zero_inds,
       n_visits = n_visits,
       n_subjects = n_subjects,
       subject_zero_inds = subject_zero_inds,

--- a/man/h_mmrm_tmb_data.Rd
+++ b/man/h_mmrm_tmb_data.Rd
@@ -46,7 +46,6 @@ columns in the original design matrix have been left out to obtain a full rank
 \code{x_matrix}.
 \item \code{y_vector}: length \code{n} \code{numeric} specifying the overall response vector.
 \item \code{weights_vector}: length \code{n} \code{numeric} specifying the weights vector.
-\item \code{visits_zero_inds}: length \code{n} \code{integer} containing zero-based visits indices.
 \item \code{n_visits}: \code{int} with the number of visits, which is the dimension of the
 covariance matrix.
 \item \code{n_subjects}: \code{int} with the number of subjects.

--- a/src/chol_cache.h
+++ b/src/chol_cache.h
@@ -42,9 +42,7 @@ struct lower_chol_nonspatial: virtual lower_chol_base<Type> {
      if (target != this->chols.end()) {
       return target->second;
     } else {
-      matrix<Type> sel_mat = get_select_matrix<Type>(visits, this->n_visits);
-      matrix<Type> Ltildei = sel_mat * this->chol_full;
-      matrix<Type> cov_i = tcrossprod(Ltildei);
+      matrix<Type> cov_i = this->get_sigma(visits, dist);
       Eigen::LLT<Eigen::Matrix<Type,Eigen::Dynamic,Eigen::Dynamic> > cov_i_chol(cov_i);
       matrix<Type> Li = cov_i_chol.matrixL();
       this->chols[visits] = Li;
@@ -56,8 +54,7 @@ struct lower_chol_nonspatial: virtual lower_chol_base<Type> {
     if (target != this->sigmas.end()) {
       return target->second;
     } else {
-      matrix<Type> sel_mat = get_select_matrix<Type>(visits, this->n_visits);
-      matrix<Type> ret = sel_mat * sigma_full * sel_mat.transpose();
+      matrix<Type> ret = subset_matrix<matrix<Type>, vector<int>>(sigma_full, visits, visits);
       this->sigmas[visits] = ret;
       return ret;
     }

--- a/src/derivatives.h
+++ b/src/derivatives.h
@@ -106,9 +106,9 @@ struct derivatives_nonspatial: public lower_chol_nonspatial<Type>, virtual deriv
       return target->second;
     } else {
       int n_visits_i = visits.size();
-      matrix<Type> ret = matrix<Type>(this->n_theta * n_visists_i, n_visists_i);
+      matrix<Type> ret = matrix<Type>(this->n_theta * n_visits_i, n_visits_i);
       for (int i = 0; i < this->n_theta; i++) {
-        ret.block(i  * n_visists_i, 0, n_visists_i, n_visists_i) = subset_matrix<matrix<Type>, vector<int>>(this->sigmad1_cache[this->full_visit].block(i  * this->n_visits, 0, this->n_visits, this->n_visits), visits, visits);
+        ret.block(i  * n_visits_i, 0, n_visits_i, n_visits_i) = subset_matrix<matrix<Type>, vector<int>>(this->sigmad1_cache[this->full_visit].block(i  * this->n_visits, 0, this->n_visits, this->n_visits), visits, visits);
       }
       this->sigmad1_cache[visits] = ret;
       return ret;
@@ -120,11 +120,11 @@ struct derivatives_nonspatial: public lower_chol_nonspatial<Type>, virtual deriv
      if (target != this->sigmad2_cache.end()) {
       return target->second;
     } else {
-      int n_visists_i = visits.size();
+      int n_visits_i = visits.size();
       int theta_sq = this->n_theta * this->n_theta;
-      matrix<Type> ret = matrix<Type>(theta_sq * n_visists_i, n_visists_i);
+      matrix<Type> ret = matrix<Type>(theta_sq * n_visits_i, n_visits_i);
       for (int i = 0; i < theta_sq; i++) {
-        ret.block(i  * n_visists_i, 0, n_visists_i, n_visists_i) = subset_matrix<matrix<Type>, vector<int>>(this->sigmad2_cache[this->full_visit].block(i  * this->n_visits, 0, this->n_visits, this->n_visits), visits, visits);
+        ret.block(i  * n_visits_i, 0, n_visits_i, n_visits_i) = subset_matrix<matrix<Type>, vector<int>>(this->sigmad2_cache[this->full_visit].block(i  * this->n_visits, 0, this->n_visits, this->n_visits), visits, visits);
       }
       this->sigmad2_cache[visits] = ret;
       return ret;

--- a/src/derivatives.h
+++ b/src/derivatives.h
@@ -105,7 +105,7 @@ struct derivatives_nonspatial: public lower_chol_nonspatial<Type>, virtual deriv
      if (target != this->sigmad1_cache.end()) {
       return target->second;
     } else {
-      int n_visists_i = visits.size();
+      int n_visits_i = visits.size();
       matrix<Type> ret = matrix<Type>(this->n_theta * n_visists_i, n_visists_i);
       for (int i = 0; i < this->n_theta; i++) {
         ret.block(i  * n_visists_i, 0, n_visists_i, n_visists_i) = subset_matrix<matrix<Type>, vector<int>>(this->sigmad1_cache[this->full_visit].block(i  * this->n_visits, 0, this->n_visits, this->n_visits), visits, visits);

--- a/src/empirical.cpp
+++ b/src/empirical.cpp
@@ -9,7 +9,6 @@ List get_empirical(List mmrm_data, NumericVector theta, NumericVector beta, Nume
   NumericVector y = mmrm_data["y_vector"];
   matrix<double> beta_vcov_matrix = as_num_matrix_tmb(beta_vcov);
   IntegerVector subject_zero_inds = mmrm_data["subject_zero_inds"];
-  IntegerVector visits_zero_inds = mmrm_data["visits_zero_inds"];
   int n_subjects = mmrm_data["n_subjects"];
   int n_observations = x_matrix.rows();
   IntegerVector subject_n_visits = mmrm_data["subject_n_visits"];
@@ -41,7 +40,7 @@ List get_empirical(List mmrm_data, NumericVector theta, NumericVector beta, Nume
     matrix<double> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
       for (int i = 0; i < n_visits_i; i++) {
-        visit_i[i] = visits_zero_inds[i + start_i];
+        visit_i[i] = int(coordinates(i + start_i, 0));
       }
     } else {
       dist_i = euclidean(matrix<double>(coords.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/jacobian.cpp
+++ b/src/jacobian.cpp
@@ -8,7 +8,6 @@ List get_jacobian(List mmrm_fit, NumericVector theta, NumericMatrix beta_vcov) {
   NumericMatrix x = mmrm_fit["x_matrix"];
   matrix<double> x_matrix = as_num_matrix_tmb(x);
   IntegerVector subject_zero_inds = mmrm_fit["subject_zero_inds"];
-  IntegerVector visits_zero_inds = mmrm_fit["visits_zero_inds"];
   int n_subjects = mmrm_fit["n_subjects"];
   IntegerVector subject_n_visits = mmrm_fit["subject_n_visits"];
   int n_visits = mmrm_fit["n_visits"];
@@ -36,7 +35,7 @@ List get_jacobian(List mmrm_fit, NumericVector theta, NumericMatrix beta_vcov) {
     matrix<double> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
       for (int i = 0; i < n_visits_i; i++) {
-        visit_i[i] = visits_zero_inds[i + start_i];
+        visit_i[i] = int(coordinates(i + start_i, 0));
       }
     } else {
       dist_i = euclidean(matrix<double>(coords.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/kr_comp.cpp
+++ b/src/kr_comp.cpp
@@ -7,7 +7,6 @@ List get_pqr(List mmrm_fit, NumericVector theta) {
   NumericMatrix x = mmrm_fit["x_matrix"];
   matrix<double> x_matrix = as_num_matrix_tmb(x);
   IntegerVector subject_zero_inds = mmrm_fit["subject_zero_inds"];
-  IntegerVector visits_zero_inds = mmrm_fit["visits_zero_inds"];
   int n_subjects = mmrm_fit["n_subjects"];
   IntegerVector subject_n_visits = mmrm_fit["subject_n_visits"];
   int n_visits = mmrm_fit["n_visits"];
@@ -36,7 +35,7 @@ List get_pqr(List mmrm_fit, NumericVector theta) {
     matrix<double> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
       for (int i = 0; i < n_visits_i; i++) {
-        visit_i[i] = visits_zero_inds[i + start_i];
+        visit_i[i] = int(coordinates(i + start_i, 0));
       }
     } else {
       dist_i = euclidean(matrix<double>(coords.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/mmrm.cpp
+++ b/src/mmrm.cpp
@@ -69,9 +69,8 @@ Type objective_function<Type>::operator() ()
     std::vector<int> visit_i(n_visits_i);
     matrix<Type> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
-      auto coords = coordinates.block(start_i, 0, n_visits_i, 1).vec();
       for (int j = 0; j < n_visits_i; j++) {
-        visit_i[j] = int(coords(j));
+        visit_i[j] = int(coordinates(start_i + j, 0));
       }
     } else {
       dist_i = euclidean(matrix<Type>(coordinates.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/mmrm.cpp
+++ b/src/mmrm.cpp
@@ -70,7 +70,7 @@ Type objective_function<Type>::operator() ()
     matrix<Type> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
       for (int j = 0; j < n_visits_i; j++) {
-        visit_i[j] = int(coordinates(start_i + j, 0));
+        visit_i[j] = int(asDouble(coordinates(start_i + j, 0)));
       }
     } else {
       dist_i = euclidean(matrix<Type>(coordinates.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/mmrm.cpp
+++ b/src/mmrm.cpp
@@ -31,7 +31,6 @@ Type objective_function<Type>::operator() ()
   DATA_MATRIX(x_matrix);           // Model matrix (dimension n x p).
   DATA_VECTOR(y_vector);           // Response vector (length n).
   DATA_VECTOR(weights_vector);     // Weights vector (length n).
-  DATA_IVECTOR(visits_zero_inds);  // Zero-based Visits vector (length n).
   DATA_MATRIX(coordinates);        // Coordinates matrix.
   DATA_INTEGER(n_visits);          // Number of visits, which is the dimension of the covariance matrix.
   DATA_INTEGER(n_subjects);        // Number of subjects.
@@ -70,8 +69,9 @@ Type objective_function<Type>::operator() ()
     std::vector<int> visit_i(n_visits_i);
     matrix<Type> dist_i(n_visits_i, n_visits_i);
     if (!is_spatial) {
-      for (int i = 0; i < n_visits_i; i++) {
-        visit_i[i] = visits_zero_inds[i + start_i];
+      auto coords = coordinates.block(start_i, 0, n_visits_i, 1).vec();
+      for (int j = 0; j < n_visits_i; j++) {
+        visit_i[j] = int(coords(j));
       }
     } else {
       dist_i = euclidean(matrix<Type>(coordinates.block(start_i, 0, n_visits_i, coordinates.cols())));

--- a/src/test-derivatives.cpp
+++ b/src/test-derivatives.cpp
@@ -32,9 +32,6 @@ context("derivatives_nonspatial struct works as expected") {
     matrix<double> dist(0, 0);
     auto full_sigma = mychol.get_sigma(v_full, dist);
     auto part_sigma = mychol.get_sigma(v1, dist);
-    auto selmat = get_select_matrix<double>(v1, 4);
-    expect_equal_matrix(matrix<double>(selmat), matrix<double>(mychol.get_sel_mat(v1)));
-    expect_equal_matrix(matrix<double>(selmat * full_sigma.block(0,0,4,4) * selmat.transpose()), matrix<double>(part_sigma.block(0,0,3,3)));
     auto full_inverse = matrix<double>(mychol.get_sigma_inverse(v_full, dist));
     matrix<double> expected_inverse(4, 4);
     // expected values from R side solve

--- a/src/test-utils.cpp
+++ b/src/test-utils.cpp
@@ -3,24 +3,6 @@
 
 using namespace Rcpp;
 
-context("get_select_matrix") {
-  test_that("get_select_matrix works as expected") {
-    vector<int> visits_i1 {{0, 3, 5}};
-    Eigen::SparseMatrix<double> result = get_select_matrix<double>(visits_i1, 7);
-    matrix<double> expected(3, 7);
-    expected <<
-      1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-      0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-      0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0;
-    matrix<double> result_dense(result);
-    expect_equal_matrix(result_dense, expected);
-    std::vector<int> visits_i2 {{0, 3, 5}};
-    Eigen::SparseMatrix<double> result2 = get_select_matrix<double>(visits_i2, 7);
-    matrix<double> result_dense2(result2);
-    expect_equal_matrix(result_dense2, expected);
-  }
-}
-
 context("tcrossprod") {
   test_that("tcrossprod works as expected with complete") {
     matrix<double> lower_chol(2, 2);

--- a/src/test-utils.cpp
+++ b/src/test-utils.cpp
@@ -3,6 +3,31 @@
 
 using namespace Rcpp;
 
+context("subset_matrix") {
+  test_that("subset_matrix works as expected") {
+    matrix<double> mat(3, 3);
+    mat <<
+      1.0, 0.0, 0.5,
+      6.0, 2.0, 1.0,
+      3.0, 0.1, 0.2;
+    std::vector<int> index {1, 0};
+    matrix<double> result1 = subset_matrix(mat, index, index);
+    matrix<double> exp1(2, 2);
+    exp1 <<
+      2.0, 6.0,
+      0.0, 1.0;
+    expect_equal_matrix(result1, exp1);
+
+    matrix<double> result2 = subset_matrix(mat, index);
+
+    matrix<double> exp2(2, 3);
+    exp2 <<
+      6.0, 2.0, 1.0,
+      1.0, 0.0, 0.5;
+    expect_equal_matrix(result2, exp2);
+  }
+}
+
 context("tcrossprod") {
   test_that("tcrossprod works as expected with complete") {
     matrix<double> lower_chol(2, 2);

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,27 +9,15 @@
 #define as_num_vector_tmb as_vector<vector<double>, NumericVector>
 #define as_num_vector_rcpp as_vector<NumericVector, vector<double>>
 
-// Producing a sparse selection matrix to select rows and columns from
-// covariance matrix.
-template <class Type>
-Eigen::SparseMatrix<Type> get_select_matrix(const vector<int>& visits_i, const int& n_visits) {
-  Eigen::SparseMatrix<Type> result(visits_i.size(), n_visits);
-  for (int i = 0; i < visits_i.size(); i++) {
-    result.insert(i, visits_i(i)) = (Type) 1.0;
-  }
-  return result;
+// Obtain submatrix from index
+
+template <typename T1, typename T2>
+T1 subset_matrix(T1 input, T2 index1, T2 index2) {
+  T1 ret(index1.size(), index2.size());
+  
 }
 
-// Producing a sparse selection matrix from visits to select rows and columns from
-// covariance matrix.
-template <class Type>
-Eigen::SparseMatrix<Type> get_select_matrix(const std::vector<int>& visits_i, const int& n_visits) {
-  Eigen::SparseMatrix<Type> result(visits_i.size(), n_visits);
-  for (std::size_t i = 0, max = visits_i.size(); i != max; ++i) {
-    result.insert(i, visits_i[i]) = (Type) 1.0;
-  }
-  return result;
-}
+
 // Conversion from Rcpp vector/matrix to eigen vector/matrix
 template <typename T1, typename T2>
 T1 as_vector(T2 input) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,6 +22,17 @@ T1 subset_matrix(T1 input, T2 index1, T2 index2) {
   return ret;
 }
 
+template <typename T1, typename T2>
+T1 subset_matrix(T1 input, T2 index1) {
+  T1 ret(index1.size(), input.cols());
+  for (int i = 0; i < index1.size(); i++) {
+    for (int j = 0; j < input.cols(); j++) {
+      ret(i, j) = input(index1[i], j);
+    }
+  }
+  return ret;
+}
+
 
 // Conversion from Rcpp vector/matrix to eigen vector/matrix
 template <typename T1, typename T2>

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,23 +13,31 @@
 
 template <typename T1, typename T2>
 T1 subset_matrix(T1 input, T2 index1, T2 index2) {
-  T1 ret(index1.size(), index2.size());
-  for (int i = 0; i < index1.size(); i++) {
-    for (int j = 0; j < index2.size(); j++) {
-      ret(i, j) = input(index1[i], index2[j]);
+  #if EIGEN_VERSION_AT_LEAST(3,4,0)
+    T1 ret = input(index1, index2);
+  #else
+    T1 ret(index1.size(), index2.size());
+    for (int i = 0; i < index1.size(); i++) {
+      for (int j = 0; j < index2.size(); j++) {
+        ret(i, j) = input(index1[i], index2[j]);
+      }
     }
-  }
+  #endif
   return ret;
 }
 
 template <typename T1, typename T2>
 T1 subset_matrix(T1 input, T2 index1) {
-  T1 ret(index1.size(), input.cols());
-  for (int i = 0; i < index1.size(); i++) {
-    for (int j = 0; j < input.cols(); j++) {
-      ret(i, j) = input(index1[i], j);
+  #if EIGEN_VERSION_AT_LEAST(3,4,0)
+    T1 ret = input(index1, Eigen::placeholders::all);
+  #else
+    T1 ret(index1.size(), input.cols());
+    for (int i = 0; i < index1.size(); i++) {
+      for (int j = 0; j < input.cols(); j++) {
+        ret(i, j) = input(index1[i], j);
+      }
     }
-  }
+  #endif
   return ret;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -14,7 +14,12 @@
 template <typename T1, typename T2>
 T1 subset_matrix(T1 input, T2 index1, T2 index2) {
   T1 ret(index1.size(), index2.size());
-  
+  for (int i = 0; i < index1.size(); i++) {
+    for (int j = 0; j < index2.size(); j++) {
+      ret(i, j) = input(index1[i], index2[j]);
+    }
+  }
+  return ret;
 }
 
 

--- a/tests/testthat/test-tmb.R
+++ b/tests/testthat/test-tmb.R
@@ -160,14 +160,13 @@ test_that("h_mmrm_tmb_data works as expected", {
     result,
     c(
       "full_frame", "data", "x_matrix", "x_cols_aliased", "coordinates", "y_vector",
-      "weights_vector", "visits_zero_inds", "n_visits", "n_subjects",
+      "weights_vector", "n_visits", "n_subjects",
       "subject_zero_inds", "subject_n_visits", "cov_type", "is_spatial_int", "reml",
       "subject_groups", "n_groups"
     )
   )
   expect_matrix(result$x_matrix, nrows = 537, ncols = 3, any.missing = FALSE)
   expect_numeric(result$y_vector, len = 537, any.missing = FALSE)
-  expect_integer(result$visits_zero_inds, len = 537, lower = 0, upper = 3, any.missing = FALSE)
   expect_identical(result$n_visits, 4L) # 4 visits.
   expect_integer(result$subject_zero_inds, len = 197, unique = TRUE, sorted = TRUE, any.missing = FALSE)
   expect_identical(result$cov_type, "us") # unstructured.
@@ -193,14 +192,13 @@ test_that("h_mmrm_tmb_data works as expected with allow_na_response", {
     result,
     c(
       "full_frame", "data", "x_matrix", "x_cols_aliased", "coordinates", "y_vector",
-      "weights_vector", "visits_zero_inds", "n_visits", "n_subjects",
+      "weights_vector", "n_visits", "n_subjects",
       "subject_zero_inds", "subject_n_visits", "cov_type", "is_spatial_int", "reml",
       "subject_groups", "n_groups"
     )
   )
   expect_matrix(result$x_matrix, nrows = 800, ncols = 3, any.missing = FALSE)
   expect_numeric(result$y_vector, len = 800, any.missing = TRUE)
-  expect_integer(result$visits_zero_inds, len = 800, lower = 0, upper = 3, any.missing = FALSE)
   expect_identical(result$n_visits, 4L) # 4 visits.
   expect_integer(result$subject_zero_inds, len = 200, unique = TRUE, sorted = TRUE, any.missing = FALSE)
   expect_identical(result$cov_type, "us") # unstructured.
@@ -228,14 +226,13 @@ test_that("h_mmrm_tmb_data do not allow NA in covariates with allow_na_response"
     result,
     c(
       "full_frame", "data", "x_matrix", "x_cols_aliased", "coordinates", "y_vector",
-      "weights_vector", "visits_zero_inds", "n_visits", "n_subjects",
+      "weights_vector", "n_visits", "n_subjects",
       "subject_zero_inds", "subject_n_visits", "cov_type", "is_spatial_int", "reml",
       "subject_groups", "n_groups"
     )
   )
   expect_matrix(result$x_matrix, nrows = 780, ncols = 3, any.missing = FALSE)
   expect_numeric(result$y_vector, len = 780, any.missing = TRUE)
-  expect_integer(result$visits_zero_inds, len = 780, lower = 0, upper = 3, any.missing = FALSE)
   expect_identical(result$n_visits, 4L) # 4 visits.
   expect_integer(result$subject_zero_inds, len = 195, unique = TRUE, sorted = TRUE, any.missing = FALSE)
   expect_identical(result$cov_type, "us") # unstructured.
@@ -260,13 +257,12 @@ test_that("h_mmrm_tmb_data works as expected for grouped covariance", {
     result,
     c(
       "full_frame", "data", "x_matrix", "x_cols_aliased", "coordinates", "y_vector",
-      "weights_vector", "visits_zero_inds", "n_visits", "n_subjects", "subject_zero_inds",
+      "weights_vector", "n_visits", "n_subjects", "subject_zero_inds",
       "subject_n_visits", "cov_type", "is_spatial_int", "reml", "subject_groups", "n_groups"
     )
   )
   expect_matrix(result$x_matrix, nrows = 537, ncols = 3, any.missing = FALSE)
   expect_numeric(result$y_vector, len = 537, any.missing = FALSE)
-  expect_integer(result$visits_zero_inds, len = 537, lower = 0, upper = 3, any.missing = FALSE)
   expect_identical(result$n_visits, 4L) # 4 visits.
   expect_integer(result$subject_zero_inds, len = 197, unique = TRUE, sorted = TRUE, any.missing = FALSE)
   expect_identical(result$cov_type, "us") # unstructured.
@@ -291,7 +287,7 @@ test_that("h_mmrm_tmb_data works as expected for mutli-dimensional spatial expon
     result,
     c(
       "full_frame", "data", "x_matrix", "x_cols_aliased", "coordinates", "y_vector",
-      "weights_vector", "visits_zero_inds", "n_visits", "n_subjects", "subject_zero_inds",
+      "weights_vector", "n_visits", "n_subjects", "subject_zero_inds",
       "subject_n_visits", "cov_type", "is_spatial_int", "reml", "subject_groups", "n_groups"
     )
   )


### PR DESCRIPTION
close #110

current implementation unifies coordinates and visits.

There is an extra data conversion so it is expected there is a small cost.
Average computation time for `FEV1 ~ ARMCD + us(AVISIT|USUBJID)`  on `fev_data` decrease from 37.53347 ms to 37.89274 ms (but still very small and neglectable I think)

In addition, the select matrix is removed but instead use "subset_matrix" functionality