### PR TITLE
add staged deps

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -1,0 +1,8 @@
+current_repo:
+  repo: openpharma/mmrm
+  host: https://github.com
+upstream_repos:
+downstream_repos:
+  insightsengineering/tern.mmrm:
+    repo: insightsengineering/tern.mmrm
+    host: https://github.com


### PR DESCRIPTION
this is only needed temporarily for downstream `tern.mmrm` as long as `mmrm` is not yet on CRAN. This should not impact anything else in a negative way.