### PR TITLE
fix issue of h_record_all_outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-- Previously if an optimizer fails `h_record_all_output` will return a `list()` or `try-error`. Now only `try-error` will be returned.
+- Previously if a secondary optimizer fails `mmrm` will fail. This is fixed now.
 
 # mmrm 0.3.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Fix internal test skipping functions for MacOS R. 
 
+### Bug Fixes
+
+- Previously if an optimizer fails `h_record_all_output` will return a `list()` or `try-error`. Now only `try-error` will be returned.
+
 # mmrm 0.3.9
 
 ### Miscellaneous

--- a/R/fit.R
+++ b/R/fit.R
@@ -441,15 +441,15 @@ mmrm <- function(formula,
     drop_visit_levels = control$drop_visit_levels,
     allow_na_response = FALSE
   )
-  fit <- list()
+  fit <- structure("", class = "try-error")
   names_all_optimizers <- names(control$optimizers)
-  while ((length(fit) == 0) && length(control$optimizers) > 0) {
+  while (is(fit, "try-error") && length(control$optimizers) > 0) {
     fit <- fit_single_optimizer(
       tmb_data = tmb_data,
       formula_parts = formula_parts,
       control = control
     )
-    if (length(fit) == 0) {
+    if (is(fit, "try-error")) {
       warning(paste0(
         "Divergence with optimizer ", names(control$optimizers[1L]), " due to problems: ",
         toString(attr(fit, "divergence"))

--- a/R/tmb-methods.R
+++ b/R/tmb-methods.R
@@ -514,7 +514,8 @@ print.mmrm_tmb <- function(x,
   cat(ifelse(component(x, "convergence") == 0, "\nConverged", "\nFailed to converge"))
   cat(
     " with code", component(x, "convergence"),
-    "and message:", tolower(component(x, "conv_message"))
+    "and message:",
+    if (is.null(component(x, "conv_message"))) "No message provided." else tolower(component(x, "conv_message"))
   )
   cat("\n")
   invisible(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,12 +26,13 @@ h_record_all_output <- function(expr,
                                 remove = list(),
                                 divergence = list()) {
   # Note: We don't need to and cannot assert `expr` here.
-  assert_list(remove)
+  assert_list(remove, types = "character")
+  assert_list(divergence, types = "character")
   env <- new.env()
   result <- withCallingHandlers(
     withRestarts(
       expr,
-      muffleStop = function() list()
+      muffleStop = function(e) structure(e$message, class = "try-error")
     ),
     message = function(m) {
       msg_without_newline <- gsub(m$message, pattern = "\n$", replacement = "")
@@ -44,7 +45,7 @@ h_record_all_output <- function(expr,
     },
     error = function(e) {
       env$error <- c(env$error, e$message)
-      invokeRestart("muffleStop")
+      invokeRestart("muffleStop", e)
     }
   )
   list(

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -458,6 +458,18 @@ test_that("mmrm returns the correct best fit", {
   )
 })
 
+test_that("divergent optimizer will not be marked as success", {
+  fev <- fev_data
+  fev$FEV1[seq(1, 800, 4)] <- 0
+  expect_error(
+    expect_warning(
+      mmrm(FEV1 ~ AVISIT + us(AVISIT | USUBJID), data = fev),
+      "Divergence with optimizer"
+    ),
+    "No optimizer led to a successful model fit."
+  )
+})
+
 ## start values ----
 
 test_that("start can be emp_start or std_start and they work", {


### PR DESCRIPTION
I can not produce examples that `h_record_all_outputs` that can create a "try-error" object, but only returns `list()` on any error, unless there is some internal `try(expr, silent=T)` in `fit_mmrm` call, however I did not find such things that could potentially return the "try-error" object. any ideas @danielinteractive ?


