### PR TITLE
fix anova error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - Previously if a secondary optimizer fails `mmrm` will fail. This is fixed now.
+- Previously character covariate variable will make `Anova` fail. This is fixed now.
 
 # mmrm 0.3.9
 

--- a/R/interop-car.R
+++ b/R/interop-car.R
@@ -64,7 +64,9 @@ h_get_contrast <- function(object, effect, type = c("II", "III", "2", "3"), tol 
         },
         "3" = ,
         "III" = {
-          additional_levels <- vapply(data[additional_vars], function(x) nlevels(x), FUN.VALUE = 1L)
+          additional_levels <- vapply(data[additional_vars], function(x) {
+            if (is.factor(x)) nlevels(x) else length(unique(x))
+          }, FUN.VALUE = 1L)
           t_levels <- prod(additional_levels)
           l_mx[, cols] / t_levels
         }

--- a/R/interop-car.R
+++ b/R/interop-car.R
@@ -40,7 +40,7 @@ h_get_contrast <- function(object, effect, type = c("II", "III", "2", "3"), tol 
   assert_subset(effect, colnames(fcts))
   idx <- which(effect == colnames(fcts))
   cols <- which(asg == idx)
-  data <- component(object, "full_frame")
+  data <- model.frame(object)
   var_numeric <- vapply(data, is.numeric, FUN.VALUE = TRUE)
   coef_rows <- length(cols)
   l_mx <- matrix(0, nrow = coef_rows, ncol = length(asg))

--- a/tests/testthat/test-car.R
+++ b/tests/testthat/test-car.R
@@ -58,6 +58,24 @@ test_that("Anova works as expected", {
   )
 })
 
+## Anova with character covariates
+
+test_that("Anova works if covariate are character", {
+  skip_if_not_installed("car")
+  fev2 <- fev_data
+  fev2$ARMCD <- as.character(fev2$ARMCD)
+  fit <- mmrm(FEV1 ~ ARMCD * AVISIT + ar1(AVISIT | USUBJID), data = fev2)
+  fit2 <- mmrm(FEV1 ~ ARMCD * AVISIT + ar1(AVISIT | USUBJID), data = fev_data)
+  expect_identical(
+    Anova(fit, "III"),
+    Anova(fit2, "III")
+  )
+  expect_identical(
+    Anova(fit, "II"),
+    Anova(fit2, "II")
+  )
+})
+
 # Anova Integration Test ----
 
 test_that("Anova give similar results to SAS", {


### PR DESCRIPTION
close #426 

previously all covariate are treated as factor.
Now there is a additional check for anova, to provide length of unique character values, instead of the nlevels functions to count the levels.

In addition, the data used, is not `component(obj, "full_frame")` (which may contain character variable) now. it is using `model.frame(obj)` to ensure everything is a factor.

The reason is that in most of our analysis we want to ensure that factors are used, to avoid potential issues (like difference in orders of factor that could lead to incorrect predict etc)