### PR TITLE
backslashes to escape ()<> in URL

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(
 Mixed models for repeated measures (MMRM) are a popular
 choice for analyzing longitudinal continuous outcomes in randomized
 clinical trials and beyond; see
-[Cnaan, Laird and Slasor (1997)](https://doi.org/10.1002%2f%28SICI%291097-0258%2819971030%2916%3a20%3c2349%3a%3aAID-SIM667%3e3.0.CO%3b2-E)
+[Cnaan, Laird and Slasor (1997)](https://doi.org/10.1002/\(SICI\)1097-0258\(19971030\)16:20\<2349::AID-SIM667\>3.0.CO;2-E)
 for a tutorial and
 [Mallinckrodt, Lane and Schnell (2008)](https://doi.org/10.1177/009286150804200402)
 for a review. This package implements

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 <!-- markdownlint-disable-file -->
+
 <!-- README.md needs to be generated from README.Rmd. Please edit that file -->
 
 # mmrm <img src="man/figures/logo.svg" align="right" width="175" />
@@ -22,7 +23,7 @@ Coverage](https://raw.githubusercontent.com/openpharma/mmrm/_xml_coverage_report
 Mixed models for repeated measures (MMRM) are a popular choice for
 analyzing longitudinal continuous outcomes in randomized clinical trials
 and beyond; see [Cnaan, Laird and Slasor
-(1997)](https://doi.org/10.1002%2f%28SICI%291097-0258%2819971030%2916%3a20%3c2349%3a%3aAID-SIM667%3e3.0.CO%3b2-E)
+(1997)](https://doi.org/10.1002/(SICI)1097-0258(19971030)16:20%3C2349::AID-SIM667%3E3.0.CO;2-E)
 for a tutorial and [Mallinckrodt, Lane and Schnell
 (2008)](https://doi.org/10.1177/009286150804200402) for a review. This
 package implements MMRM based on the marginal linear model without


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

# Description

<!-- Please describe your PR here -->
I tested using backslashes to escape ()<> in the [Cnaan, Laird and Slasor (1997)](https://doi.org/10.1002/(SICI)1097-0258(19971030)16:20%3C2349::AID-SIM667%3E3.0.CO;2-E) hyperlink in README.Rmd and README.md. This hyperlink had been throwing a "Forbidden" error in the automated in the URL checker. 

I wanted to confirm that:
1. The hyperlink would work on the GitHub README, and
2. The URL checker would stop throwing the "Forbidden" error.

The link worked, but the URL check was skipped (among others), and I don't know why. 

Regardless, I am initiating this pull request because all checks that were run did pass. If this is ill-advised, it can be abandoned.