### PR TITLE
Fix AR correlation structure in `gls` calls

### DIFF
--- a/vignettes/mmrm_review_methods.Rmd
+++ b/vignettes/mmrm_review_methods.Rmd
@@ -196,7 +196,7 @@ MODEL FEV1 = AVISIT|ARMCD / ddfm=satterthwaite solution chisq;
 <pre><code>gls(
   FEV1 ~ ARMCD * AVISIT,
   data = fev_data,
-  correlation = <b>corCAR1(form = ~AVISIT | USUBJID)</b>,
+  correlation = <b>corAR1(form = ~AVISIT | USUBJID)</b>,
   weights = <b>varIdent(form = ~1|AVISIT)</b>,
   na.action = na.omit
 )
@@ -222,7 +222,7 @@ MODEL FEV1 =  ARMCD|AVISIT / ddfm=satterthwaite solution chisq;
 <pre><code>gls(
   FEV1 ~ ARMCD * AVISIT,
   data = fev_data,
-  correlation = <b>corCAR1(form = ~AVISIT | USUBJID)</b>,
+  correlation = <b>corAR1(form = ~AVISIT | USUBJID)</b>,
   na.action = na.omit
 )
 </code></pre>


### PR DESCRIPTION
Tackling issue #511.

`corCAR1` is used to model continuous AR(1) correlation structures and it does only work with integer valued covariates.
Therefore, in the vignette "Comparison with other software", the correlation structure in `gls` calls is changed to `corAR1`. In addition, the non-continuous AR1 correlation structure is also what SAS and {mmrm} use.
