### PR TITLE
make h_get_minimal_fit_data() extract names from calls

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -769,14 +769,19 @@ h_fits_common_data <- function(fits) {
 #' @keywords internal
 h_get_minimal_fit_data <- function(fit) {
   assert_class(fit, "mmrm")
-  predictors <-
-    fit[["formula_parts"]][
-      c("visit_var", "subject_var", "group_var", "model_var")
-    ]
-  predictors <- unique(unlist(predictors, use.names = FALSE))
+  covariance_vars <-
+    fit[["formula_parts"]][c("visit_var", "subject_var", "group_var")]
+  covariance_vars <- Filter(length, covariance_vars)
+  covariance_vars <- lapply(covariance_vars, str2lang)
+  covariance_vars <- lapply(covariance_vars, all.vars)
+  covariance_vars <- unlist(covariance_vars, use.names = FALSE)
+  predictors <- c(covariance_vars, fit[["formula_parts"]][["model_var"]])
+  predictors <- unique(predictors)
   terms_attr <- attributes(terms(fit))
-  response <- as.character(terms_attr$variables[[terms_attr$response + 1]])
-  fit[["data"]][c(response, predictors)]
+  response <- all.vars(terms_attr$variables[[terms_attr$response + 1]])
+  cols <- c(response, predictors)
+  cols <- intersect(cols, colnames(fit[["data"]]))
+  fit[["data"]][cols]
 }
 
 

--- a/tests/testthat/helper-examples.R
+++ b/tests/testthat/helper-examples.R
@@ -22,7 +22,8 @@ get_mmrm_transformed <- function() {
 }
 
 .mmrm_trans <- mmrm(
-  FEV1 ~ log(FEV1_BL) + ARMCD * AVISIT + ar1(AVISIT | USUBJID),
+  identity(FEV1) ~
+    log(FEV1_BL) + ARMCD * AVISIT + ar1(as.ordered(AVISIT) | USUBJID),
   data = fev_data
 )
 

--- a/tests/testthat/test-mmrm-methods.R
+++ b/tests/testthat/test-mmrm-methods.R
@@ -253,6 +253,13 @@ test_that("h_get_minimal_fit_data() grabs only colums used in model fitting", {
     h_get_minimal_fit_data(get_mmrm()),
     fev_data[c("FEV1", "AVISIT", "USUBJID", "RACE", "SEX", "ARMCD")]
   )
+
+  # Account for model terms that are calls instead of just symbols (e.g., log(x)
+  # as opposed to just x)
+  expect_equal(
+    h_get_minimal_fit_data(get_mmrm_trans()),
+    fev_data[c("FEV1", "AVISIT", "USUBJID", "FEV1_BL", "ARMCD")]
+  )
 })
 
 test_that("h_check_covar_nesting() ensures models have nested covariates", {


### PR DESCRIPTION
The helper function `h_get_minimal_fit_data()` naively grabbed the lefthand side of the model formula as well as the covariance structure variables and treated them as column names that might be found in `data`. The issue with this is that these elements could be calls rather than just symbols (i.e., `log(x)` instead of just `x`). This pull request extracts names from these elements before looking for them in `data`.