### PR TITLE
Fix issue #561

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,10 +6,9 @@
 - `mmrm_control()` gains `emmeans_gcomp_vars` argument, enabling G-computation correction in `emmeans()` output for models with covariate-by-treatment interactions. When set, `emmeans()` returns the average treatment effect (ATE) with standard errors that account for covariate variability across subjects. See `?emmeans_support` for details.
 - `mmrm` now supports the spatial Gaussian (`sp_gau`) covariance structure.
 
-# mmrm 0.3.17.9000
-
 ### Bug Fixes
 
+- Previously, using `emmeans()` on a model fitted to a dataset with only a single visit would fail, because the visit variable was always included in the design matrix and a contrast could not be constructed for this factor variable having only a single level. This is now fixed.
 - Previously, having the visit variable only in an interaction term in the model could lead to failed `emmeans()` evaluation. Similarly, there could be other interaction variable problems potentially with `emmeans()`, due to the change in the order which is automatically applied by `terms()` used internally. This is now fixed.
 
 # mmrm 0.3.17

--- a/R/interop-emmeans.R
+++ b/R/interop-emmeans.R
@@ -69,12 +69,17 @@ recover_data.mmrm <- function(object, ...) {
   # subject_var is excluded because it should not contain fixed effect.
   # visit_var is only excluded for spatial covariance structures -
   # for non-spatial covariance structures, emmeans can provide marginal mean
-  # by each visit so we need visit_var.
+  # by each visit so we need visit_var. Also exclude visit_var when it has only
+  # one level (emmeans cannot contrast it).
+  visit_var <- object$formula_parts$visit_var
+  exclude_visit <- object$formula_parts$is_spatial ||
+    nlevels(object$tmb_data$full_frame[[visit_var]]) < 2L
+
   model_frame <- stats::model.frame(
     object,
     exclude = c(
       "subject_var",
-      if (object$formula_parts$is_spatial) "visit_var"
+      if (exclude_visit) "visit_var"
     )
   )
   model_terms <- stats::delete.response(stats::terms(model_frame))

--- a/tests/testthat/test-emmeans.R
+++ b/tests/testthat/test-emmeans.R
@@ -375,3 +375,35 @@ test_that("emmeans also works when the visit variable is not part of the covaria
   )
   result <- expect_silent(emmeans::emmeans(fit, ~ ARMCD | AVISIT))
 })
+
+test_that("emmeans works for single-visit MMRM (ANCOVA edge case)", {
+  skip_if_not_installed("emmeans", minimum_version = "1.6")
+  mydata <- droplevels(fev_data[fev_data$AVISIT == "VIS1", ])
+  fm <- mmrm(FEV1 ~ FEV1_BL + ARMCD + us(AVISIT | USUBJID), data = mydata)
+  emm <- as.data.frame(emmeans::emmeans(fm, ~ ARMCD))
+  expect_equal(nrow(emm), 2L)
+  expect_true(all(is.finite(emm$SE)))
+})
+
+test_that("single-visit MMRM emmeans matches lm", {
+  skip_if_not_installed("emmeans", minimum_version = "1.6")
+  mydata <- droplevels(fev_data[fev_data$AVISIT == "VIS1", ])
+  fm_mmrm <- mmrm(FEV1 ~ FEV1_BL + ARMCD + us(AVISIT | USUBJID), data = mydata)
+  fm_lm <- lm(FEV1 ~ FEV1_BL + ARMCD, data = mydata)
+  emm_mmrm <- as.data.frame(emmeans::emmeans(fm_mmrm, ~ ARMCD))
+  emm_lm <- as.data.frame(emmeans::emmeans(fm_lm, ~ ARMCD))
+  expect_equal(emm_mmrm$emmean, emm_lm$emmean, tolerance = 1e-4)
+  expect_equal(emm_mmrm$SE, emm_lm$SE, tolerance = 1e-4)
+})
+
+test_that("emmeans works for single-visit MMRM without droplevels", {
+  skip_if_not_installed("emmeans", minimum_version = "1.6")
+  mydata <- fev_data[fev_data$AVISIT == "VIS1", ]
+  expect_message(
+    fm <- mmrm(FEV1 ~ FEV1_BL + ARMCD + us(AVISIT | USUBJID), data = mydata),
+    "dropped visits"
+  )
+  emm <- as.data.frame(emmeans::emmeans(fm, ~ ARMCD))
+  expect_equal(nrow(emm), 2L)
+  expect_true(all(is.finite(emm$SE)))
+})


### PR DESCRIPTION
This is a fix for issue #561. Currently `visit_var` with only one level get passed to `emm_basis.mmrm()` and this breaks on the contrasts. Removing at the `recover_data.mmrm()` along with the existing exclusions ensures all passes to `emm_basis.mmrm()` are covered. Confirmed to pass the exact edge case presented in #561. Three tests added confirming the fix.